### PR TITLE
Generate stats cards for profile on README

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,40 @@
+name: Update README cards
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Generate stats card
+        uses: stats-organization/github-readme-stats-action@b4d2ef3b8051484b318d455163153b23a2b35fa2 # v1.1.0
+        with:
+          card: stats
+          options: username=${{ github.repository_owner }}&theme=tokyonight
+          path: profile/stats.svg
+          token: ${{ github.token }}
+
+      - name: Generate top languages card
+        uses: stats-organization/github-readme-stats-action@b4d2ef3b8051484b318d455163153b23a2b35fa2 # v1.1.0
+        with:
+          card: top-langs
+          options: username=${{ github.repository_owner }}&theme=tokyonight&layout=compact
+          path: profile/top-langs.svg
+          token: ${{ github.token }}
+
+      - name: Commit cards
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git add profile/*.svg
+          git commit -m "Update README cards" || exit 0
+          git push


### PR DESCRIPTION
The public instance of github-readme-stats isn't reliable, so this commit allows to generate stats cards via GitHub Actions.

Ref:
- https://github.com/stats-organization/github-readme-stats/blob/1ba8beb7ac3c0989cc281f253f9477cf6e7d2768/readme.md#deploy-on-your-own-recommended
- https://github.com/stats-organization/github-readme-stats-action